### PR TITLE
Added part of speech restrictions for baselines.

### DIFF
--- a/pywsd/baseline.py
+++ b/pywsd/baseline.py
@@ -10,13 +10,20 @@ from nltk.corpus import wordnet as wn
 import random
 random.seed(0)
 
-def random_sense(ambiguous_word):
+def random_sense(ambiguous_word, pos=None):
     """ Returns a ramdom sense. """
-    return random.choice(wn.synsets(ambiguous_word))
+    if pos is None:
+        return random.choice(wn.synsets(ambiguous_word))
+    else:
+        return random.choice(wn.synsets(ambiguous_word, pos))
 
-def first_sense(ambiguous_word):
+
+def first_sense(ambiguous_word, pos=None):
     """ Returns the first sense."""
-    return wn.synsets(ambiguous_word)[0]
+    if pos is None:
+        return wn.synsets(ambiguous_word)[0]
+    else:
+        return wn.synsets(ambiguous_word, pos)[0]
 
 def max_lemma_count(ambiguous_word):
     """ 


### PR DESCRIPTION
- A POS tag can now be provided for `first_sense` and `random_sense` functions, allowing the WordNet synsets to be restricted to the corresponding POS.