### PR TITLE
Add the ability to pass a custom tokenizer to disambiguate via an argument

### DIFF
--- a/pywsd/allwords_wsd.py
+++ b/pywsd/allwords_wsd.py
@@ -28,11 +28,11 @@ stopwords = stopwords.words('english') + list(punctuation)
 
 def disambiguate(sentence, algorithm=simple_lesk,
                  context_is_lemmatized=False, similarity_option='path',
-                 keepLemmas=False, prefersNone=True):
+                 keepLemmas=False, prefersNone=True, tokenizer=word_tokenize):
     tagged_sentence = []
     # Pre-lemmatize the sentnece before WSD
     if not context_is_lemmatized:
-        surface_words, lemmas, morphy_poss = lemmatize_sentence(sentence, keepWordPOS=True)
+        surface_words, lemmas, morphy_poss = lemmatize_sentence(sentence, keepWordPOS=True, tokenizer=tokenizer)
         lemma_sentence = " ".join(lemmas)
     else:
         lemma_sentence = sentence # TODO: Miss out on POS specification, how to resolve?


### PR DESCRIPTION
It would be nice to have the ability to pass a different tokenizer to the disambiguate function for better compatibility when using different tools (e.g., when using pre-tokenized text simply split on whitespace, or pass an alternative tokenizer to NLTK's word_tokenize [e.g., Stanford]). This is important since some tokenizers produce a different set/number of tokens based on internal rules, which can lead to inconsistency in terms of how many tokens are being returned by disambiguate vs. other tools.